### PR TITLE
Add track descriptions to CFP

### DIFF
--- a/content/blog/cfp-open.md
+++ b/content/blog/cfp-open.md
@@ -34,7 +34,7 @@ We welcome submissions on any topic related to the Apache Software Foundation, A
 * Tomcat, Httpd and other servers
 
 Additionally, we are thrilled to introduce a new feature this year: a
-poster session. This addition will provide an excellent platform for
+**poster session**. This addition will provide an excellent platform for
 showcasing high-level projects and incubator initiatives in a visually
 engaging manner. We believe this will foster lively discussions and
 facilitate networking opportunities among participants.
@@ -45,4 +45,90 @@ All my best, and thanks so much for your participation,
 
 Ryan Skraba (on behalf of the program committee)
 
+---
 
+### Track descriptions
+
+**API & Microservices**:
+Open-source API and Microservices projects in the ASF; for example, Apache APISIX, Apache Shenyu, Apache Camel, Apache Dubbo, etc.
+
+**Big Data Compute**:
+Big Data is nothing but a massive dataset that can be processed across clusters of computers to find insights.
+As the data grows, the requirements of data processing keep growing.
+Heavy computing frameworks and capabilities are necessary for many use cases, such as delivering analytics on Big Data faster, or preprocessing data for machine learning and AI.
+Fortunately, there are mature Big Data Compute projects (like Apache Spark, Apache Hadoop, Apache Flink) and a vibrant ecosystem of related projects within the ASF.
+
+This track welcomes submissions about improving existing projects or creating new ones to solve computing needs in Big Data.
+ 
+**Big Data Storage**:
+Big Data is nothing but a massive dataset requiring massive storage capability, and Big Data Storage projects (like Apache HDFS or Apache Ozone) are the backbone for Big Data innovations.
+With the continuous growth of data, there's an increasing need for scalable solutions.
+Some cloud storage innovations address these scaling requirements, but performance remains a key factor for latency sensitive use cases.
+Open source software projects are continually innovating both in cloud and on-premise environments.
+
+This track welcomes submissions related to innovation and improvements in the storage software space.
+
+**Cassandra**:
+All things Apache Cassandra, focusing on 5.0 features, what's next in 5.1, how we do engineering, and our community.
+
+**CloudStack**:
+Presenting the new Apache CloudStack release, new integrations and capabilities and user stories.
+
+**Community**:
+Community, Governance, and Culture, covering the social and organizational aspects of ASF projects, and the Foundation at large.
+Topics might include community building, diversity, governance, collaboration, culture, and open source history.
+
+**Data Engineering**:
+The open-source tools and libraries we use to clean the data, build data tools, orchestrate workloads, do observability, visualization, data lineage and many other tasks that are part of data engineering.
+It is about the often-unheard open-source tools that are part of (or integrate with) the open-source data (and big data) ecosystem and the role they play in the modern data stack.
+
+The Data Engineering track is all about the indispensable tools you need to use in order to get your data under control.
+You don't often hear about the tools and platforms used to keep your data in check from the data scientists and analysts.
+The goal of those tools is to be invisible and do the job.
+If your data engineering tools did a good job — you rarely talk about them.
+So let's talk about the Data Engineering tools and explain the role they play in a modern data stack.
+
+**Fintech**:
+Led by the Apache Fineract project, exploring the intersection of finance and open-source technologies, two of the most rapidly evolving industries today.
+The track provides a platform for experts within the ASF community to share their knowledge and insights on Fintech's latest trends, challenges, and opportunities.
+It welcomes talks on any Fintech and open-source topic, including unique perspectives on specific projects or broader topics of interest to the community.
+Ultimately, the Fintech track aims to foster innovation, collaboration, and progress across the industry. 
+
+**Groovy**:
+All aspects of the Apache Groovy language and its usage, including its use with the many Groovy frameworks and its usage with JVM libraries when leveraging Groovy features. 
+
+**Incubator**:
+About the incubating process and incubating projects.
+
+**IoT**:
+Projects in the IoT or industrial IoT (IIoT) sector.
+
+**Performance Engineering**:
+Many Apache projects address domains with software performance and scalability challenges (e.g. Web, Cloud, Databases, Streaming Data, Big Data, Data Analytics, Search, Geospatial, etc), while others provide performance engineering tools (e.g. benchmarking, testing, monitoring, etc) that are widely used, so the track will provide opportunities for cross-fertilization between projects of different software categories and maturity.
+
+Performance Engineering is the science and practice of engineering software so that it is fast and scalable.
+Performance Engineering in the open-source community is pervasive and includes (but is not limited to) methods and tools for software performance architecting, design, operation, end-user experience, benchmarking, load testing, monitoring, distributed tracing, analysis, prediction, modeling and simulation, regression testing, optimization and tuning, and source code analysis, profiling and instrumentation techniques.
+
+We welcome submissions related to open-source software performance engineering best practices, tools, techniques, results, challenges & lessons learned, etc, particularly demonstrating experiences relevant to:
+* Apache software projects
+* In-house, managed service and cloud providers of Apache software
+* End-users of Apache Software
+* The wider open-source, developer and research communities.
+
+**Posters**:
+Posters about ASF projects and topics of interest to ASF projects.
+Posters with original research are more likely to be accepted.
+We are looking for ideas and concepts that are applicable across projects.
+Posters do not have to be associated with an ASF project.
+Access/use of all information presented or referenced may not be inhibited by patent or other licensing restrictions. 
+
+**Search**:
+This is a track for "All things Search".
+Apache Lucene and Solr have been the leaders in defining the space for over a decade.
+Since their incubation, they have grown to redefine 'Search' from being limited to full text lookup to also include spatial search, analytics, and a lot more.
+This track welcomes submissions about Information Retrieval, analytics, the Lucene and Solr community, Machine Learning in search, deployment and management of large scale search systems, etc.
+
+**Tomcat, Httpd and other servers**:
+Web Servers and Application Servers are used mostly everywhere.
+This track will host Apache Tomcat, Apache HTTPD server and Traffic Server, and other related projects in the ecosystem.
+New protocols and new specifications in the area will be presented.

--- a/content/blog/cfp-open.md
+++ b/content/blog/cfp-open.md
@@ -75,7 +75,7 @@ All things Apache Cassandra, focusing on 5.0 features, what's next in 5.1, how w
 Presenting the new Apache CloudStack release, new integrations and capabilities and user stories.
 
 **Community**:
-Community, Governance, and Culture, covering the social and organizational aspects of ASF projects, and the Foundation at large.
+This track covers the Community, Governance, and Culture, including the social and organizational aspects, of ASF projects and the Foundation at large.
 Topics might include community building, diversity, governance, collaboration, culture, and open source history.
 
 **Data Engineering**:
@@ -120,7 +120,7 @@ Posters about ASF projects and topics of interest to ASF projects.
 Posters with original research are more likely to be accepted.
 We are looking for ideas and concepts that are applicable across projects.
 Posters do not have to be associated with an ASF project.
-Access/use of all information presented or referenced may not be inhibited by patent or other licensing restrictions. 
+Access/use of all information presented or referenced must be unencumbered by by patent or other licensing restrictions. 
 
 **Search**:
 This is a track for "All things Search".


### PR DESCRIPTION
As requested and started by @Claudenw, it's useful to have the track descriptions available!

I rewrote some of the texts to be a bit more consistent with each other without changing the meaning, but it's pretty obvious they all have different authors.  I asked permission where I made larger changes.
